### PR TITLE
Suppress TapcpTransport._logger.warning when try different protocols

### DIFF
--- a/src/casperfpga.py
+++ b/src/casperfpga.py
@@ -81,8 +81,12 @@ def choose_transport(host_ip):
             # it can be re-set afterwards if tftp connects ok.
             log_level = get_log_level()
             set_log_level(logging.CRITICAL)
+            # Same for the log level of TapcpTransport
+            taploglevel = board._logger.level
+            board._logger.setLevel(logging.ERROR)
             if board.is_connected():
                 set_log_level(log_level)
+                board._logger.setLevel(taploglevel)
                 LOGGER.debug('%s seems to be a Tapcp host' % host_ip)
                 return TapcpTransport
         LOGGER.debug('%s seems to be a ROACH' % host_ip)


### PR DESCRIPTION
But still when connecting RPI compliant devices you can see katcp warning like this:
WARNING:casperfpga.transport_katcp:10.1.0.23: no ._stream instance found.